### PR TITLE
Fixed error for `type`

### DIFF
--- a/utility/ensure.js
+++ b/utility/ensure.js
@@ -23,8 +23,6 @@ module.exports = {
         }
         if (types.length > 1) {
             throw new TypeError(`Expected one of "${types.join('", "')}" but instead found "${type(obj)}"`);
-        } else {
-            throw new TypeError(`Expected "${types[0]}" but instead found "${type(obj)}"`);
         }
     },
 


### PR DESCRIPTION
Fixed error for `type` method: `TypeError: Right-hand side of 'instanceof' is not an object`, and removed the check for greater than one (>) that was not required since`["one"].join(", ")` returns "one"