### PR TITLE
Fixed error for `type` (updated without mistakes)

### DIFF
--- a/utility/ensure.js
+++ b/utility/ensure.js
@@ -19,12 +19,10 @@ module.exports = {
             types.push('undefined');
         }
         for (const t of types) {
-            if (type(obj) === t.toLowerCase() || obj instanceof t) return;
+            if (type(obj) === t.toLowerCase()) return;
         }
         if (types.length > 1) {
             throw new TypeError(`Expected one of "${types.join('", "')}" but instead found "${type(obj)}"`);
-        } else {
-            throw new TypeError(`Expected "${types[0]}" but instead found "${type(obj)}"`);
         }
     },
 


### PR DESCRIPTION
Fixed error for `type` method: `TypeError: Right-hand side of 'instanceof' is not an object`, and removed the check for greater than one (>) that was not required since`["one"].join(", ")` returns "one"