### PR TITLE
docs(math): add return type to all math methods

### DIFF
--- a/cherry/index.js
+++ b/cherry/index.js
@@ -485,6 +485,7 @@ module.exports = class Cherry extends Object {
      * @param {string} path - The path of the value to perform math on
      * @param {string} operation - The operation to perform on the number
      * @param {number} operand - The other operand for the given operation
+     * @returns {number}
      */
     math(path, operation, operand) {
         ensure.type(path, 'string');
@@ -506,6 +507,7 @@ module.exports = class Cherry extends Object {
     /**
      * Increment a value
      * @param {string} path - The path at which to increment the value
+     * @returns {number}
      */
     inc(path) {
         return this.add(path, 1);
@@ -514,6 +516,7 @@ module.exports = class Cherry extends Object {
     /**
      * Decrement a value
      * @param {string} path - The path at which to decrement the value
+     * @returns {number}
      */
     dec(path) {
         return this.sub(path, 1);
@@ -523,6 +526,7 @@ module.exports = class Cherry extends Object {
      * Add to a value
      * @param {string} path - The path at which to add
      * @param {number} operand - The amount to add to the value at the given path
+     * @returns {number}
      */
     add(path, operand) {
         return this.math(path, 'add', operand);
@@ -532,6 +536,7 @@ module.exports = class Cherry extends Object {
      * Subtract from a value
      * @param {string} path - The path at which to subtract
      * @param {number} operand - The amount to subtract from the value at the given path
+     * @returns {number}
      */
     sub(path, operand) {
         return this.math(path, 'sub', operand);
@@ -541,6 +546,7 @@ module.exports = class Cherry extends Object {
      * Multiply a value
      * @param {string} path - The path at which to multiply
      * @param {number} operand - The amount to multiply the value at the given path by
+     * @returns {number}
      */
     mul(path, operand) {
         return this.math(path, 'mul', operand);
@@ -550,6 +556,7 @@ module.exports = class Cherry extends Object {
      * Divide from a value
      * @param {string} path - The path at which to divide
      * @param {number} operand - The amount to divide the value at the given path by
+     * @returns {number}
      */
     div(path, operand) {
         return this.math(path, 'div', operand);
@@ -559,6 +566,7 @@ module.exports = class Cherry extends Object {
      * Mod a value
      * @param {string} path - The path at which to mod
      * @param {number} operand - The amount to mod the value at the given path by
+     * @returns {number}
      */
     mod(path, operand) {
         return this.math(path, 'mod', operand);
@@ -568,6 +576,7 @@ module.exports = class Cherry extends Object {
      * Apply an exponent to a value
      * @param {string} path - The path at which to apply the exponent
      * @param {number} operand - The exponent to apply to the value at the given path
+     * @returns {number}
      */
     pow(path, operand) {
         return this.math(path, 'pow', operand);


### PR DESCRIPTION
This PR adds the return type to the `math` method as `number` to keep consistency and proper documentation.